### PR TITLE
Enable host and port option when launching the gui

### DIFF
--- a/R/gui.R
+++ b/R/gui.R
@@ -14,10 +14,10 @@
 #' }
 #'
 #' @export
-gui = function () {
+gui = function (port = getOption("shiny.port"), host = getOption("shiny.host", "127.0.0.1")) {
   appDir <- system.file("shiny", "gui", package = "SSDM")
   if (appDir == "") {
     stop("Could not find example directory. Try re-installing `mypackage`.", call. = FALSE)
   }
-  shiny::runApp(appDir, display.mode = "normal")
+  shiny::runApp(appDir, display.mode = "normal", port = port, host = host)
 }


### PR DESCRIPTION
Yo crazy colibri, I slightly changed the code for launching the gui, enabling the user to select the port and the host of the shiny web server. We're about to install the gui in our brand new server (called niamoto, hinano had not been retained as a proper name), Robin needs to test easily the power of the beast (64Gb of RAM, Xeon e5 - 6 cores/12 threads) for our niche modeling needs. I'm sure it will be fine valuable! Hope your doing well eating your beer flavored chicken tandoori.

Cheers mate,

Dim'