### PR TITLE
Implement parLapply for 'project'

### DIFF
--- a/man/project.Rd
+++ b/man/project.Rd
@@ -15,7 +15,8 @@ project(obj, Env, ...)
 
 \S4method{project}{MAXENT.SDM}(obj, Env, ...)
 
-\S4method{project}{Ensemble.SDM}(obj, Env, ...)
+\S4method{project}{Ensemble.SDM}(obj, Env, cores = 1, verbose = TRUE,
+  ...)
 
 \S4method{project}{Stacked.SDM}(obj, Env, ...)
 }


### PR DESCRIPTION
This version includes the option to parallelize the `raster::predict` function of `project`. For the minimal example, setting up a cluster took way more time than actually running the code. Hence parallelization should only be considered when `raster::predict` would take a long time to run. Also, since there is no efficient way of exporting objects to the workers selectively yet, parallelization with many cores will usually run into memory issues quite fast. Maybe this can be treated in later versions of this pull request.