### PR TITLE
Fixed issue 108: load_model failed

### DIFF
--- a/R/save.model.R
+++ b/R/save.model.R
@@ -66,7 +66,7 @@ setMethod('save.esdm', 'Ensemble.SDM', function (esdm,
   if (verbose) {
     cat("   tables ...")
   }
-  write.csv(esdm@evaluation, paste0(path, "/", name, "/Tables/esdmeval.csv"))
+  write.csv(esdm@evaluation, paste0(path, "/", name, "/Tables/ESDMeval.csv"))
   write.csv(esdm@algorithm.evaluation, paste0(path, "/", name, "/Tables/AlgoEval.csv"))
   write.csv(esdm@algorithm.correlation, paste0(path, "/", name, "/Tables/AlgoCorr.csv"))
   write.csv(esdm@variable.importance, paste0(path, "/", name, "/Tables/VarImp.csv"))


### PR DESCRIPTION
The save.model.R file in current version of SSDM creates an esdmeval.csv file under Model/Species/Species_Name/Tables, but the load.model.R code expects the file to be named ESDMeval.csv and throws an error when attempting to load the saved model.

This branch edits this save.model.R file and on testing, successfully names the files produced as ESDMeval.csv and allows models to load without errors.

Testing done on a HPC cluster using a Singularity container.